### PR TITLE
Move the default 'btn' class to the method signature

### DIFF
--- a/src/TypiCMS/BootForms/BasicFormBuilder.php
+++ b/src/TypiCMS/BootForms/BasicFormBuilder.php
@@ -51,14 +51,14 @@ class BasicFormBuilder
         return $this->formGroup($label, $name, $control);
     }
 
-    public function button($value, $name = null, $type = 'btn-secondary')
+    public function button($value, $name = null, $type = 'btn btn-secondary')
     {
-        return $this->builder->button($value, $name)->addClass('btn')->addClass($type);
+        return $this->builder->button($value, $name)->addClass($type);
     }
 
-    public function submit($value = 'Submit', $type = 'btn-primary')
+    public function submit($value = 'Submit', $type = 'btn btn-primary')
     {
-        return $this->builder->submit($value)->addClass('btn')->addClass($type);
+        return $this->builder->submit($value)->addClass($type);
     }
 
     public function select($label, $name, $options = [])


### PR DESCRIPTION
Enforcing the 'btn' class really isn't necessary, when you can just set it as a changeable default in the method signature.  This way someone can pass exactly the Bootstrap classes they want (e.g. 'btn-sm'), and not be stuck with full-size buttons.