### PR TITLE
Bootstrap 4 Addons

### DIFF
--- a/src/TypiCMS/BootForms/Elements/InputGroup.php
+++ b/src/TypiCMS/BootForms/Elements/InputGroup.php
@@ -31,12 +31,12 @@ class InputGroup extends Text
         return $this;
     }
 
-    protected function renderAddons($addons)
+    protected function renderAddons($addons, $class)
     {
         $html = '';
 
         foreach ($addons as $addon) {
-            $html .= '<span class="input-group-addon">';
+            $html .= sprintf('<span class="input-group-%s">', $class);
             $html .= $addon;
             $html .= '</span>';
         }
@@ -47,9 +47,9 @@ class InputGroup extends Text
     public function render()
     {
         $html = '<div class="input-group">';
-        $html .= $this->renderAddons($this->beforeAddon);
+        $html .= $this->renderAddons($this->beforeAddon, 'prepend');
         $html .= parent::render();
-        $html .= $this->renderAddons($this->afterAddon);
+        $html .= $this->renderAddons($this->afterAddon, 'append');
         $html .= '</div>';
 
         return $html;

--- a/tests/BasicFormBuilderTest.php
+++ b/tests/BasicFormBuilderTest.php
@@ -563,21 +563,21 @@ class BasicFormBuilderTest extends TestCase
 
     public function testRenderInputGroupWithBeforeAddon()
     {
-        $expected = '<div class="form-group"><label for="username">Username</label><div class="input-group"><span class="input-group-addon">@</span><input type="text" name="username" id="username" class="form-control"></div></div>';
+        $expected = '<div class="form-group"><label for="username">Username</label><div class="input-group"><span class="input-group-prepend">@</span><input type="text" name="username" id="username" class="form-control"></div></div>';
         $result = $this->form->inputGroup('Username', 'username')->beforeAddon('@')->render();
         $this->assertEquals($expected, $result);
     }
 
     public function testRenderInputGroupWithAfterAddon()
     {
-        $expected = '<div class="form-group"><label for="site">Site</label><div class="input-group"><input type="text" name="site" id="site" class="form-control"><span class="input-group-addon">.com.br</span></div></div>';
+        $expected = '<div class="form-group"><label for="site">Site</label><div class="input-group"><input type="text" name="site" id="site" class="form-control"><span class="input-group-append">.com.br</span></div></div>';
         $result = $this->form->inputGroup('Site', 'site')->afterAddon('.com.br')->render();
         $this->assertEquals($expected, $result);
     }
 
     public function testRenderInputGroupChangeTypeWithBothAddon()
     {
-        $expected = '<div class="form-group"><label for="secret">Secret</label><div class="input-group"><span class="input-group-addon">before</span><input type="password" name="secret" id="secret" class="form-control"><span class="input-group-addon">after</span></div></div>';
+        $expected = '<div class="form-group"><label for="secret">Secret</label><div class="input-group"><span class="input-group-prepend">before</span><input type="password" name="secret" id="secret" class="form-control"><span class="input-group-append">after</span></div></div>';
         $result = $this->form
             ->inputGroup('Secret', 'secret')
             ->type('password')

--- a/tests/InputGroupTest.php
+++ b/tests/InputGroupTest.php
@@ -20,7 +20,7 @@ class InputGroupTest extends TestCase
         $input = new InputGroup('username');
         $this->assertEquals($input, $input->beforeAddon('@'));
 
-        $expected = '<div class="input-group"><span class="input-group-addon">@</span><input type="text" name="username"></div>';
+        $expected = '<div class="input-group"><span class="input-group-prepend">@</span><input type="text" name="username"></div>';
         $result = $input->render();
         $this->assertEquals($expected, $result);
     }
@@ -31,7 +31,7 @@ class InputGroupTest extends TestCase
         $this->assertEquals($input, $input->type('email'));
         $this->assertEquals($input, $input->afterAddon('@domain.com'));
 
-        $expected = '<div class="input-group"><input type="email" name="mail"><span class="input-group-addon">@domain.com</span></div>';
+        $expected = '<div class="input-group"><input type="email" name="mail"><span class="input-group-append">@domain.com</span></div>';
         $result = $input->render();
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
This PR uses for [Bootstrap 4 addons](https://getbootstrap.com/docs/4.1/components/input-group/#basic-example).

```
{!!
    BootForm::inputGroup('Budget','budget')
        ->beforeAddon('<span class="input-group-text">£</span>')
!!}
```